### PR TITLE
Remove lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
 		"cli-cursor": "^2.1.0",
 		"commander": "^2.12.2",
 		"hms-parse": "^1.0.0",
-		"lodash": "^4.17.4",
 		"play-sound": "^1.1.2",
 		"timercore": "^1.0.2"
 	}

--- a/src/renderFactory.js
+++ b/src/renderFactory.js
@@ -1,7 +1,6 @@
 const {cursorTo, clearScreenDown} = require('readline')
 const {EOL} = require('os')
 const hms = require('hms-parse')
-const zipWith = require('lodash/zipWith')
 const {
 	zero,
 	one,
@@ -40,11 +39,16 @@ const INDENT = ' '.repeat(8)
 const PADDING = EOL.repeat(3)
 const SPACING = ' '.repeat(2)
 
-const getLine = (...segments) => INDENT + segments.join(SPACING)
+const zipWith = (a, f) =>
+	(a[0].reduce((acc, _, i) =>
+		acc.concat([a.reduce((out, inner) =>
+			out.concat(inner[i]), [])]), [])).map(f)
+
+const getLine = segments => INDENT + segments.join(SPACING)
 
 const getOutput = hmsString => {
 	const characters = [...hmsString].map(val => map[val])
-	const lines = zipWith(...characters, getLine)
+	const lines = zipWith(characters, getLine)
 	return PADDING + lines.join(EOL) + PADDING
 }
 


### PR DESCRIPTION
Since lodash was only being used for the zipWith function, went ahead and wrote a small drop in replacement that accomplishes _pretty much_ the same thing. Reduces download time, especially for people like me who run litetimer without globally installing it `npx litetimer 2m` :)

Let me know if I can improve it or anything